### PR TITLE
Fixed a problem with mzML reader failing for non-compressed files

### DIFF
--- a/src/META-INF/MANIFEST.MF
+++ b/src/META-INF/MANIFEST.MF
@@ -1,3 +1,3 @@
 Manifest-Version: 1.0
-Main-Class: lucXor.LucXor
+Main-Class: lucxor.LucXor
 

--- a/src/lucxor/FLRClass.java
+++ b/src/lucxor/FLRClass.java
@@ -2,7 +2,7 @@
  * To change this template, choose Tools | Templates
  * and open the template in the editor.
  */
-package lucXor;
+package lucxor;
 
 import gnu.trove.map.hash.THashMap;
 

--- a/src/lucxor/LucXor.java
+++ b/src/lucxor/LucXor.java
@@ -2,7 +2,7 @@
  * To change this template, choose Tools | Templates
  * and open the template in the editor.
  */
-package lucXor;
+package lucxor;
 
 import java.io.*;
 import java.util.*;

--- a/src/lucxor/ModelData_CID.java
+++ b/src/lucxor/ModelData_CID.java
@@ -2,7 +2,7 @@
  * To change this template, choose Tools | Templates
  * and open the template in the editor.
  */
-package lucXor;
+package lucxor;
 
 import java.io.BufferedWriter;
 import java.io.File;

--- a/src/lucxor/ModelData_HCD.java
+++ b/src/lucxor/ModelData_HCD.java
@@ -2,7 +2,7 @@
  * To change this template, choose Tools | Templates
  * and open the template in the editor.
  */
-package lucXor;
+package lucxor;
 
 import java.io.BufferedWriter;
 import java.io.File;

--- a/src/lucxor/ModelParameterWorkerThread.java
+++ b/src/lucxor/ModelParameterWorkerThread.java
@@ -1,4 +1,4 @@
-package lucXor;
+package lucxor;
 
 /**
  * Created by dfermin on 5/15/14.

--- a/src/lucxor/NormalDensityWorkerThread.java
+++ b/src/lucxor/NormalDensityWorkerThread.java
@@ -2,7 +2,7 @@
  * To change this template, choose Tools | Templates
  * and open the template in the editor.
  */
-package lucXor;
+package lucxor;
 
 import java.util.concurrent.Callable;
 import org.apache.commons.math3.util.FastMath;

--- a/src/lucxor/PSM.java
+++ b/src/lucxor/PSM.java
@@ -2,23 +2,16 @@
  * To change this template, choose Tools | Templates
  * and open the template in the editor.
  */
-package lucXor;
+package lucxor;
 
-import com.sun.xml.internal.bind.v2.runtime.reflect.Lister;
-import gnu.trove.TCollections;
-import gnu.trove.list.array.TDoubleArrayList;
-import gnu.trove.list.array.TIntArrayList;
-import gnu.trove.map.hash.TDoubleIntHashMap;
 import gnu.trove.map.hash.TDoubleObjectHashMap;
 import gnu.trove.map.hash.THashMap;
 import gnu.trove.map.hash.TIntDoubleHashMap;
-import gnu.trove.set.hash.TIntHashSet;
 
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
-import java.lang.reflect.Array;
 import java.util.*;
 import java.util.Map.Entry;
 import java.util.regex.Matcher;

--- a/src/lucxor/PeakClass.java
+++ b/src/lucxor/PeakClass.java
@@ -2,7 +2,7 @@
  * To change this template, choose Tools | Templates
  * and open the template in the editor.
  */
-package lucXor;
+package lucxor;
 
 import java.util.Comparator;
 

--- a/src/lucxor/PepXML.java
+++ b/src/lucxor/PepXML.java
@@ -2,7 +2,7 @@
  * To change this template, choose Tools | Templates
  * and open the template in the editor.
  */
-package lucXor;
+package lucxor;
 
 import java.io.File;
 import java.io.IOException;

--- a/src/lucxor/Peptide.java
+++ b/src/lucxor/Peptide.java
@@ -2,21 +2,16 @@
  * To change this template, choose Tools | Templates
  * and open the template in the editor.
  */
-package lucXor;
-
-import com.google.common.collect.ArrayListMultimap;
+package lucxor;
 
 import java.util.*;
 import java.util.Map.Entry;
 
-import gnu.trove.impl.hash.TIntDoubleHash;
 import gnu.trove.list.TIntList;
-import gnu.trove.list.array.TDoubleArrayList;
 import gnu.trove.list.array.TIntArrayList;
 import gnu.trove.map.hash.TDoubleObjectHashMap;
 import gnu.trove.map.hash.THashMap;
 import gnu.trove.map.hash.TIntDoubleHashMap;
-import gnu.trove.procedure.TIntDoubleProcedure;
 import org.apache.commons.math3.util.FastMath;
 
 /**

--- a/src/lucxor/ScoringWorkerThread.java
+++ b/src/lucxor/ScoringWorkerThread.java
@@ -1,4 +1,4 @@
-package lucXor;
+package lucxor;
 
 import java.io.IOException;
 

--- a/src/lucxor/SpectrumClass.java
+++ b/src/lucxor/SpectrumClass.java
@@ -1,4 +1,4 @@
-package lucXor;
+package lucxor;
 
 
 import gnu.trove.list.array.TIntArrayList;

--- a/src/lucxor/constants.java
+++ b/src/lucxor/constants.java
@@ -2,7 +2,7 @@
  * To change this template, choose Tools | Templates
  * and open the template in the editor.
  */
-package lucXor;
+package lucxor;
 
 /**
  *

--- a/src/lucxor/globals.java
+++ b/src/lucxor/globals.java
@@ -2,14 +2,13 @@
  * To change this template, choose Tools | Templates
  * and open the template in the editor.
  */
-package lucXor;
+package lucxor;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
 import java.io.*;
 import java.text.SimpleDateFormat;
 import java.util.*;
-import java.util.concurrent.ArrayBlockingQueue;
 import java.util.zip.DataFormatException;
 import javax.xml.parsers.ParserConfigurationException;
 

--- a/src/lucxor/mzMLreader.java
+++ b/src/lucxor/mzMLreader.java
@@ -1,22 +1,18 @@
-package lucXor;
+package lucxor;
 
 import gnu.trove.map.hash.TIntObjectHashMap;
-import org.apache.commons.codec.binary.Base64;
 import org.xml.sax.Attributes;
 import org.xml.sax.SAXException;
 import org.xml.sax.helpers.DefaultHandler;
-import sun.misc.BASE64Decoder;
 
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.parsers.SAXParser;
 import javax.xml.parsers.SAXParserFactory;
 import java.io.File;
 import java.io.IOException;
-import java.nio.ByteOrder;
 import java.util.zip.Inflater;
 
 import java.io.ByteArrayOutputStream;
-import java.nio.ByteBuffer;
 import java.util.zip.DataFormatException;
 
 
@@ -362,5 +358,4 @@ public class mzMLreader extends DefaultHandler {
         }
         return ret.intensity_;
     }
-
 }

--- a/src/lucxor/statsFunctions.java
+++ b/src/lucxor/statsFunctions.java
@@ -2,13 +2,11 @@
  * To change this template, choose Tools | Templates
  * and open the template in the editor.
  */
-package lucXor;
+package lucxor;
 
 import java.util.ArrayList;
 import java.util.concurrent.ExecutionException;
 
-import gnu.trove.TDecorators;
-import gnu.trove.list.TIntList;
 import gnu.trove.list.array.TIntArrayList;
 import org.paukov.combinatorics.Factory;
 import org.paukov.combinatorics.Generator;


### PR DESCRIPTION
It wasn't compiling, so I had to change package name to lowercase.
The mzML reader couldn't read a non-compressed file, now it should not fail. Turns out, that in mzML there are 2 separate accessions: one for compression enabled and one for compression disabled.
